### PR TITLE
Adding deploy.yaml pattern for ping-pong-mesh

### DIFF
--- a/workloads/ping-pong-mesh/client/deploy.yaml
+++ b/workloads/ping-pong-mesh/client/deploy.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ping-pong-client
+  labels:
+    app: ping-pong-client
+    mode: cofide
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-pong-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ping-pong-client
+      mode: cofide
+  template:
+    metadata:
+      labels:
+        app: ping-pong-client
+        mode: cofide
+    spec:
+      serviceAccountName: ping-pong-client
+      containers:
+      - name: ping-pong-client
+        image: ko://github.com/cofide/cofide-demos/workloads/ping-pong-mesh/client
+        env:
+        - name: PING_PONG_SERVICE_HOST
+          value: "${PING_PONG_SERVER_SERVICE_HOST}"
+        - name: PING_PONG_SERVICE_PORT
+          value: "${PING_PONG_SERVER_SERVICE_PORT}"

--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ping-pong-server
+  labels:
+    app: ping-pong-server
+    mode: cofide
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-pong-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ping-pong-server
+      mode: cofide
+  template:
+    metadata:
+      labels:
+        app: ping-pong-server
+        mode: cofide
+    spec:
+      serviceAccountName: ping-pong-server
+      containers:
+      - name: ping-pong-server
+        image: ko://github.com/cofide/cofide-demos/workloads/ping-pong-mesh/server
+        ports:
+        - containerPort: 8443
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ping-pong-server
+spec:
+  selector:
+    app: ping-pong-server
+    mode: cofide
+  ports:
+    - protocol: TCP
+      port: 8443
+      targetPort: 8443
+  type: LoadBalancer

--- a/workloads/ping-pong-mesh/server/main.go
+++ b/workloads/ping-pong-mesh/server/main.go
@@ -29,7 +29,7 @@ func getEnvWithDefault(variable string, defaultValue string) string {
 
 func getEnv() *Env {
 	return &Env{
-		Port: getEnvWithDefault("PORT", ":9090"),
+		Port: getEnvWithDefault("PORT", ":8443"),
 	}
 }
 


### PR DESCRIPTION
Making `ping-pong-mesh` consistent with the pattern used in `ping-pong` (i.e. adding `deploy.yaml` for each)