### PR TITLE
Adding relevant Istio config to mesh workloads

### DIFF
--- a/workloads/ping-pong-mesh/client/deploy.yaml
+++ b/workloads/ping-pong-mesh/client/deploy.yaml
@@ -22,6 +22,14 @@ spec:
       labels:
         app: ping-pong-client
         mode: cofide
+        spiffe.io/spire-managed-identity: "true"
+        sidecar.istio.io/inject: "true"
+      annotations:
+        proxy.istio.io/config: |
+          proxyMetadata:
+            ISTIO_META_DNS_CAPTURE: "true"
+            ISTIO_META_DNS_AUTO_ALLOCATE: "true"
+        inject.istio.io/templates: "sidecar,spire"
     spec:
       serviceAccountName: ping-pong-client
       containers:

--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -22,6 +22,13 @@ spec:
       labels:
         app: ping-pong-server
         mode: cofide
+        sidecar.istio.io/inject: "true"
+      annotations:
+        proxy.istio.io/config: |
+          proxyMetadata:
+            ISTIO_META_DNS_CAPTURE: "true"
+            ISTIO_META_DNS_AUTO_ALLOCATE: "true"
+        inject.istio.io/templates: "sidecar,spire"
     spec:
       serviceAccountName: ping-pong-server
       containers:


### PR DESCRIPTION
This was missing from the `ping-pong-mesh` workloads, and is required for `cofide-connect` integration tests to work