### PR TITLE
Removing port from ping-pong-mesh client

### DIFF
--- a/workloads/ping-pong-mesh/client/deploy.yaml
+++ b/workloads/ping-pong-mesh/client/deploy.yaml
@@ -22,6 +22,14 @@ spec:
       labels:
         app: ping-pong-client
         mode: cofide
+        spiffe.io/spire-managed-identity: "true"
+        sidecar.istio.io/inject: "true"
+      annotations:
+        proxy.istio.io/config: |
+          proxyMetadata:
+            ISTIO_META_DNS_CAPTURE: "true"
+            ISTIO_META_DNS_AUTO_ALLOCATE: "true"
+        inject.istio.io/templates: "sidecar,spire"
     spec:
       serviceAccountName: ping-pong-client
       containers:

--- a/workloads/ping-pong-mesh/client/main.go
+++ b/workloads/ping-pong-mesh/client/main.go
@@ -20,8 +20,7 @@ func main() {
 }
 
 type Env struct {
-	ServerAddress    string
-	ServerPort       int
+	ServerAddress string
 }
 
 func getEnvOrPanic(variable string) string {
@@ -48,8 +47,7 @@ func getEnvIntWithDefault(variable string, defaultValue int) int {
 
 func getEnv() *Env {
 	return &Env{
-		ServerAddress:    getEnvOrPanic("PING_PONG_SERVICE_HOST"),
-		ServerPort:       getEnvIntWithDefault("PING_PONG_SERVICE_PORT", 80),
+		ServerAddress: getEnvOrPanic("PING_PONG_SERVICE_HOST"),
 	}
 }
 
@@ -60,17 +58,17 @@ func run(ctx context.Context, env *Env) error {
 
 	for {
 		slog.Info("ping...")
-		if err := ping(client, env.ServerAddress, env.ServerPort); err != nil {
+		if err := ping(client, env.ServerAddress); err != nil {
 			slog.Error("problem reaching server", "error", err)
 		}
 		time.Sleep(5 * time.Second)
 	}
 }
 
-func ping(client *http.Client, serverAddr string, serverPort int) error {
+func ping(client *http.Client, serverAddr string) error {
 	r, err := client.Get((&url.URL{
 		Scheme: "http",
-		Host:   fmt.Sprintf("%s:%d", serverAddr, serverPort),
+		Host:   fmt.Sprintf("%s", serverAddr),
 	}).String())
 
 	if err != nil {

--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -22,6 +22,13 @@ spec:
       labels:
         app: ping-pong-server
         mode: cofide
+        sidecar.istio.io/inject: "true"
+      annotations:
+        proxy.istio.io/config: |
+          proxyMetadata:
+            ISTIO_META_DNS_CAPTURE: "true"
+            ISTIO_META_DNS_AUTO_ALLOCATE: "true"
+        inject.istio.io/templates: "sidecar,spire"
     spec:
       serviceAccountName: ping-pong-server
       containers:


### PR DESCRIPTION
`FederatedService` handles the port to the upstream workload as part of the `targetPort` of the ServiceEntry, so we don't need to add this as part of the calling address