### PR TITLE
Making NAMESPACE and images injectable for each of the demo manifests

### DIFF
--- a/workloads/ping-pong-mesh/client/deploy.yaml
+++ b/workloads/ping-pong-mesh/client/deploy.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ping-pong-client
+  namespace: "${NAMESPACE}"
   labels:
     app: ping-pong-client
     mode: cofide
@@ -11,6 +12,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ping-pong-client
+  namespace: "${NAMESPACE}"
 spec:
   replicas: 1
   selector:

--- a/workloads/ping-pong-mesh/client/deploy.yaml
+++ b/workloads/ping-pong-mesh/client/deploy.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: ping-pong-client
       containers:
       - name: ping-pong-client
-        image: ko://github.com/cofide/cofide-demos/workloads/ping-pong-mesh/client
+        image: ${CLIENT_IMAGE}
         env:
         - name: PING_PONG_SERVICE_HOST
           value: "${PING_PONG_SERVER_SERVICE_HOST}"

--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ping-pong-server
+  namespace: "${NAMESPACE}"
   labels:
     app: ping-pong-server
     mode: cofide
@@ -11,6 +12,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ping-pong-server
+  namespace: "${NAMESPACE}"
 spec:
   replicas: 1
   selector:
@@ -42,6 +44,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ping-pong-server
+  namespace: "${NAMESPACE}"
 spec:
   selector:
     app: ping-pong-server

--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: ping-pong-server
       containers:
       - name: ping-pong-server
-        image: ko://github.com/cofide/cofide-demos/workloads/ping-pong-mesh/server
+        image: ${SERVER_IMAGE}
         ports:
         - containerPort: 8443
 ---


### PR DESCRIPTION
This change adds configuration to each of the `deploy.yaml` manifests, allowing for more flexibility in deployment options

* NAMESPACE
* SERVER_IMAGE
* CLIENT_IMAGE