### PR TITLE
Make server port configurable via envsubst

### DIFF
--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -36,9 +36,9 @@ spec:
         image: ko://github.com/cofide/cofide-demos/workloads/ping-pong-mesh/server
         env:
         - name: PORT
-          value: ":${PORT}"
+          value: ":${PING_PONG_SERVER_SERVICE_PORT}"
         ports:
-        - containerPort: ${PORT}
+        - containerPort: ${PING_PONG_SERVER_SERVICE_PORT}
 ---
 
 apiVersion: v1
@@ -51,6 +51,6 @@ spec:
     mode: cofide
   ports:
     - protocol: TCP
-      port: ${PORT}
-      targetPort: ${PORT}
+      port: ${PING_PONG_SERVER_SERVICE_PORT}
+      targetPort: ${PING_PONG_SERVER_SERVICE_PORT}
   type: LoadBalancer

--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -35,7 +35,8 @@ spec:
       - name: ping-pong-server
         image: ko://github.com/cofide/cofide-demos/workloads/ping-pong-mesh/server
         env:
-          PORT: "${PORT}"
+        - name: PORT
+          value: "${PORT}"
         ports:
         - containerPort: "${PORT}"
 ---

--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -34,8 +34,10 @@ spec:
       containers:
       - name: ping-pong-server
         image: ko://github.com/cofide/cofide-demos/workloads/ping-pong-mesh/server
+        env:
+          PORT: "${PORT}"
         ports:
-        - containerPort: 8443
+        - containerPort: "${PORT}"
 ---
 
 apiVersion: v1
@@ -48,6 +50,6 @@ spec:
     mode: cofide
   ports:
     - protocol: TCP
-      port: 8443
-      targetPort: 8443
+      port: "${PORT}"
+      targetPort: "${PORT}"
   type: LoadBalancer

--- a/workloads/ping-pong-mesh/server/deploy.yaml
+++ b/workloads/ping-pong-mesh/server/deploy.yaml
@@ -36,9 +36,9 @@ spec:
         image: ko://github.com/cofide/cofide-demos/workloads/ping-pong-mesh/server
         env:
         - name: PORT
-          value: "${PORT}"
+          value: ":${PORT}"
         ports:
-        - containerPort: "${PORT}"
+        - containerPort: ${PORT}
 ---
 
 apiVersion: v1
@@ -51,6 +51,6 @@ spec:
     mode: cofide
   ports:
     - protocol: TCP
-      port: "${PORT}"
-      targetPort: "${PORT}"
+      port: ${PORT}
+      targetPort: ${PORT}
   type: LoadBalancer


### PR DESCRIPTION
This enables `PORT` to be injected via `envsubst` (in a similar fashion to the existing variables in the corresponding client workload) for more configurability in the example server workload