### PR TITLE
Adding terraform for AWS OIDC resources

### DIFF
--- a/workloads/aws-oidc/terraform/iam.tf
+++ b/workloads/aws-oidc/terraform/iam.tf
@@ -1,0 +1,47 @@
+resource "aws_iam_role" "iam_role_oidc_discovery_provider" {
+  name = "${var.project_name}-oidc-discovery-provider-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${local.aws_account_id}:oidc-provider/${var.spire_oidc_discovery_provider_domain}"
+        }
+        Condition = {
+          StringEquals = {
+            "${var.spire_oidc_discovery_provider_domain}:aud" = "${var.spire_jwt_svid_audience}",
+            "${var.spire_oidc_discovery_provider_domain}:sub" = "spiffe://${var.trust_domain}/ns/${var.k8s_namespace}/sa/default"
+          }
+        }
+      }
+    ]
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_iam_role_policy" "iam_role_policy_oidc_discovery_provider" {
+  name = "${var.project_name}-oidc-discovery-provider-role-policy"
+  role = aws_iam_role.iam_role_oidc_discovery_provider.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:ListAllMyBuckets",
+          "s3:ListBucket",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/workloads/aws-oidc/terraform/locals.tf
+++ b/workloads/aws-oidc/terraform/locals.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  aws_account_id = data.aws_caller_identity.current.account_id
+}

--- a/workloads/aws-oidc/terraform/oidc.tf
+++ b/workloads/aws-oidc/terraform/oidc.tf
@@ -1,0 +1,11 @@
+data "tls_certificate" "spire_oidc_discovery_provider_tls_certificate" {
+  url = "https://${var.spire_oidc_discovery_provider_domain}/keys"
+}
+
+resource "aws_iam_openid_connect_provider" "iam_openid_connect_provider" {
+  url = "https://${var.spire_oidc_discovery_provider_domain}"
+  client_id_list = [
+    "${var.spire_jwt_svid_audience}"
+  ]
+  thumbprint_list = [data.tls_certificate.spire_oidc_discovery_provider_tls_certificate.certificates[0].sha1_fingerprint]
+}

--- a/workloads/aws-oidc/terraform/variables.tf
+++ b/workloads/aws-oidc/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "The name of the AWS region."
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "The name of the Kubernetes namespace where workloads that need to assume the IAM role reside."
+  type        = string
+}
+
+variable "project_name" {
+  description = "The name of the project."
+  type        = string
+}
+
+variable "spire_oidc_discovery_provider_domain" {
+  description = "The domain from which the SPIRE OIDC discovery provider is being served (exclude the https:// prefix)."
+  type        = string
+}
+
+variable "spire_jwt_svid_audience" {
+  description = "The JWT audience (aud) claim that identifies the recipients that the JWT is intended for."
+  type        = string
+}
+
+variable "trust_domain" {
+  description = "The trust domain where the workloads are deployed."
+  type        = string
+}

--- a/workloads/aws-oidc/terraform/versions.tf
+++ b/workloads/aws-oidc/terraform/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.48.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}


### PR DESCRIPTION
This adds example Terraform to provision the required AWS resources to enable the OIDC use case with the `aws-oidc` demo workloads