### PR TITLE
Lowering requested CPU level for AWS OIDC workloads

### DIFF
--- a/workloads/aws-oidc/aws-oidc-analysis/deploy.yaml
+++ b/workloads/aws-oidc/aws-oidc-analysis/deploy.yaml
@@ -33,7 +33,7 @@ spec:
           resources:
             requests:
               memory: "128Mi"
-              cpu: "200m"
+              cpu: "100m"
           volumeMounts:
             - name: spiffe-workload-api
               mountPath: /spiffe-workload-api

--- a/workloads/aws-oidc/aws-oidc-consumer/deploy.yaml
+++ b/workloads/aws-oidc/aws-oidc-consumer/deploy.yaml
@@ -33,7 +33,7 @@ spec:
           resources:
             requests:
               memory: "128Mi"
-              cpu: "200m"
+              cpu: "100m"
           ports:
             - containerPort: 9090
           volumeMounts:


### PR DESCRIPTION
Does what it says on the tin: lowers the requested CPU for the AWS OIDC workloads to `100m`. These are pretty small Go applications so should be fine with getting less