### PR TITLE
Configurable SPIFFEIDs for aws workloads

### DIFF
--- a/workloads/aws-oidc/aws-oidc-analysis/main.go
+++ b/workloads/aws-oidc/aws-oidc-analysis/main.go
@@ -37,10 +37,18 @@ func run(ctx context.Context) error {
 		}
 		defer source.Close()
 
+		var consumerSPIFFEID string
+		consumerSPIFFEID, ok := os.LookupEnv("CONSUMER_SPIFFEID")
+		if !ok {
+			// Default expected SPIFFEID for consumer workload
+			consumerSPIFFEID = "spiffe://%s/ns/production/sa/default"
+		}
+
 		spiffeID := fmt.Sprintf(
-			"spiffe://%s/ns/production/sa/default",
+			consumerSPIFFEID,
 			os.Getenv("CONSUMER_TRUST_DOMAIN"),
 		)
+
 		allowedSPIFFEID := spiffeid.RequireFromString(spiffeID)
 		tlsConfig = tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeID(allowedSPIFFEID))
 	}

--- a/workloads/aws-oidc/aws-oidc-analysis/main.go
+++ b/workloads/aws-oidc/aws-oidc-analysis/main.go
@@ -40,7 +40,7 @@ func run(ctx context.Context) error {
 		var consumerSPIFFEID string
 		consumerSPIFFEID, ok := os.LookupEnv("CONSUMER_SPIFFE_ID")
 		if !ok {
-			// Default expected SPIFFEID for consumer workload
+			// Default expected SPIFFE ID for consumer workload
 			consumerSPIFFEID = "spiffe://%s/ns/production/sa/default"
 		}
 

--- a/workloads/aws-oidc/aws-oidc-analysis/main.go
+++ b/workloads/aws-oidc/aws-oidc-analysis/main.go
@@ -38,7 +38,7 @@ func run(ctx context.Context) error {
 		defer source.Close()
 
 		var consumerSPIFFEID string
-		consumerSPIFFEID, ok := os.LookupEnv("CONSUMER_SPIFFEID")
+		consumerSPIFFEID, ok := os.LookupEnv("CONSUMER_SPIFFE_ID")
 		if !ok {
 			// Default expected SPIFFEID for consumer workload
 			consumerSPIFFEID = "spiffe://%s/ns/production/sa/default"

--- a/workloads/aws-oidc/aws-oidc-consumer/main.go
+++ b/workloads/aws-oidc/aws-oidc-consumer/main.go
@@ -53,8 +53,15 @@ func run(ctx context.Context) error {
 		}
 		defer source.Close()
 
+		var analysisSPIFFEID string
+		analysisSPIFFEID, ok := os.LookupEnv("ANALYSIS_SPIFFEID")
+		if !ok {
+			// Default expected SPIFFEID for analysis workload
+			analysisSPIFFEID = "spiffe://%s/ns/analytics/sa/default"
+		}
+
 		spiffeID := fmt.Sprintf(
-			"spiffe://%s/ns/analytics/sa/default",
+			analysisSPIFFEID,
 			os.Getenv("ANALYSIS_TRUST_DOMAIN"),
 		)
 		allowedSPIFFEID := spiffeid.RequireFromString(spiffeID)

--- a/workloads/aws-oidc/aws-oidc-consumer/main.go
+++ b/workloads/aws-oidc/aws-oidc-consumer/main.go
@@ -56,7 +56,7 @@ func run(ctx context.Context) error {
 		var analysisSPIFFEID string
 		analysisSPIFFEID, ok := os.LookupEnv("ANALYSIS_SPIFFE_ID")
 		if !ok {
-			// Default expected SPIFFEID for analysis workload
+			// Default expected SPIFFE ID for analysis workload
 			analysisSPIFFEID = "spiffe://%s/ns/analytics/sa/default"
 		}
 

--- a/workloads/aws-oidc/aws-oidc-consumer/main.go
+++ b/workloads/aws-oidc/aws-oidc-consumer/main.go
@@ -54,7 +54,7 @@ func run(ctx context.Context) error {
 		defer source.Close()
 
 		var analysisSPIFFEID string
-		analysisSPIFFEID, ok := os.LookupEnv("ANALYSIS_SPIFFEID")
+		analysisSPIFFEID, ok := os.LookupEnv("ANALYSIS_SPIFFE_ID")
 		if !ok {
 			// Default expected SPIFFEID for analysis workload
 			analysisSPIFFEID = "spiffe://%s/ns/analytics/sa/default"


### PR DESCRIPTION
Makes expected SPIFFEIDs for each workload in AWS use case configurable, with default value