### PR TITLE
Making SPIFFEID of consumer workload configurabled in TF

### DIFF
--- a/workloads/aws-oidc/terraform/iam.tf
+++ b/workloads/aws-oidc/terraform/iam.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "iam_role_oidc_discovery_provider" {
         Condition = {
           StringEquals = {
             "${var.spire_oidc_discovery_provider_domain}:aud" = "${var.spire_jwt_svid_audience}",
-            "${var.spire_oidc_discovery_provider_domain}:sub" = "spiffe://${var.trust_domain}/ns/${var.k8s_namespace}/sa/default"
+            "${var.spire_oidc_discovery_provider_domain}:sub" = "spiffe://${var.trust_domain}${var.consumer_spiffe_id_suffix}"
           }
         }
       }

--- a/workloads/aws-oidc/terraform/iam.tf
+++ b/workloads/aws-oidc/terraform/iam.tf
@@ -12,7 +12,7 @@ resource "aws_iam_role" "iam_role_oidc_discovery_provider" {
         Condition = {
           StringEquals = {
             "${var.spire_oidc_discovery_provider_domain}:aud" = "${var.spire_jwt_svid_audience}",
-            "${var.spire_oidc_discovery_provider_domain}:sub" = "spiffe://${var.trust_domain}${var.consumer_spiffe_id_suffix}"
+            "${var.spire_oidc_discovery_provider_domain}:sub" = "spiffe://${var.trust_domain}${var.consumer_spiffe_id_path}"
           }
         }
       }

--- a/workloads/aws-oidc/terraform/variables.tf
+++ b/workloads/aws-oidc/terraform/variables.tf
@@ -28,7 +28,7 @@ variable "trust_domain" {
   type        = string
 }
 
-variable "consumer_spiffe_id_suffix" {
-  description = "Suffix used by the consumer workload's SPIFFEID e.g. /ns/production"
+variable "consumer_spiffe_id_path" {
+  description = "Path used by the consumer workload's SPIFFEID e.g. /ns/production"
   type = string
 }

--- a/workloads/aws-oidc/terraform/variables.tf
+++ b/workloads/aws-oidc/terraform/variables.tf
@@ -27,3 +27,8 @@ variable "trust_domain" {
   description = "The trust domain where the workloads are deployed."
   type        = string
 }
+
+variable "consumer_spiffe_id_suffix" {
+  description = "Suffix used by the consumer workload's SPIFFEID e.g. /ns/production"
+  type = string
+}


### PR DESCRIPTION
This change allows for the AWS trust provider information around the consumer workload's SPIFFEID to be configurable as a variable in the example Terraform