### PR TITLE
Use ns/production as SVIDMatch condition

### DIFF
--- a/workloads/ping-pong-cofide/ping-pong-cofide-server/main.go
+++ b/workloads/ping-pong-cofide/ping-pong-cofide-server/main.go
@@ -45,7 +45,7 @@ func run(ctx context.Context, env *Env) error {
 	secureServer := cofide_http_server.NewServer(&http.Server{
 		Addr:    env.SecurePort,
 		Handler: secureMux,
-	}, cofide_http_server.WithSVIDMatch(id.Equals("sa", "ping-pong-client")),
+	}, cofide_http_server.WithSVIDMatch(id.Equals("ns", "production")),
 	)
 	secureMux.HandleFunc("/", handler(secureServer))
 


### PR DESCRIPTION
Minor adjustment to the SVID match used in the `ping-pong-cofide-client` workload - looks for `ns/production` rather than the service account (to support `trust-zone-server` default SPIFFEID formats)