### PR TITLE
Switch on `EXPERIMENTAL_ENABLE_XDS`

### DIFF
--- a/workloads/ping-pong-cofide/ping-pong-cofide-client/deploy.yaml
+++ b/workloads/ping-pong-cofide/ping-pong-cofide-client/deploy.yaml
@@ -38,6 +38,8 @@ spec:
           value: "${PING_PONG_SERVER_SERVICE_PORT}"
         - name: EXPERIMENTAL_XDS_SERVER_URI
           value: "${EXPERIMENTAL_XDS_SERVER_URI}"
+        - name: EXPERIMENTAL_ENABLE_XDS
+          value: "true"
         - name: SPIFFE_ENDPOINT_SOCKET
           value: unix:///spiffe-workload-api/spire-agent.sock
         volumeMounts:


### PR DESCRIPTION
Needs to be enabled for the SDK to patch in the CofideTransport case