### PR TITLE
Use the configured region in AWS OIDC Terraform configuration

### DIFF
--- a/workloads/aws-oidc/terraform/versions.tf
+++ b/workloads/aws-oidc/terraform/versions.tf
@@ -8,5 +8,5 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  region = var.aws_region
 }


### PR DESCRIPTION
Hello,

I think the `aws_region` variable was meant to be used to configure the Terraform AWS provider.