### PR TITLE
Fix the environment variable used for AWS_ROLE_ARN

### DIFF
--- a/workloads/aws-oidc/aws-oidc-consumer/deploy-istio.yaml
+++ b/workloads/aws-oidc/aws-oidc-consumer/deploy-istio.yaml
@@ -51,7 +51,7 @@ spec:
           - name: SPIFFE_ENDPOINT_SOCKET
             value: unix:///spiffe-workload-api/spire-agent.sock
           - name: AWS_ROLE_ARN
-            value: ${CONSUMER_AWS_ROLE_ARN}
+            value: ${AWS_ROLE_ARN}
           - name: ENABLE_TLS
             value: "false"
           - name: ANALYSIS_SPIFFE_ID

--- a/workloads/aws-oidc/aws-oidc-consumer/deploy.yaml
+++ b/workloads/aws-oidc/aws-oidc-consumer/deploy.yaml
@@ -46,7 +46,7 @@ spec:
           - name: ANALYSIS_TRUST_DOMAIN
             value: ${ANALYSIS_TRUST_DOMAIN}
           - name: AWS_ROLE_ARN
-            value: ${CONSUMER_AWS_ROLE_ARN}
+            value: ${AWS_ROLE_ARN}
           - name: ANALYSIS_SPIFFE_ID
             value: ${ANALYSIS_SPIFFE_ID}
           - name: ENABLE_TLS


### PR DESCRIPTION
The exercise says to set the AWS_ROLE_ARN environment variable, whereas the deploy configuration used the CONSUMER_AWS_ROLE_ARN variable.