### PR TITLE
fix: Add CLIENT_SPIFFE_ID to manifest

### DIFF
--- a/workloads/ping-pong/ping-pong-server/deploy.yaml
+++ b/workloads/ping-pong/ping-pong-server/deploy.yaml
@@ -41,6 +41,8 @@ spec:
         env:
         - name: SPIFFE_ENDPOINT_SOCKET
           value: unix:///spiffe-workload-api/spire-agent.sock
+        - name: CLIENT_SPIFFE_ID
+          value: "${CLIENT_SPIFFE_ID}"
       volumes:
       - name: spiffe-workload-api
         csi:


### PR DESCRIPTION
This is missing from the previous merge & release - the ping-pong server now requires a CLIENT_SPIFFE_ID for validation