### PR TITLE
Revert k8s resources renaming

### DIFF
--- a/workloads/ping-pong-cofide/ping-pong-cofide-client/deploy.yaml
+++ b/workloads/ping-pong-cofide/ping-pong-cofide-client/deploy.yaml
@@ -1,31 +1,31 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ping-pong-cofide-client
+  name: ping-pong-client
   labels:
-    app: ping-pong-cofide-client
+    app: ping-pong-client
     mode: cofide
 ---
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ping-pong-cofide-client
+  name: ping-pong-client
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ping-pong-cofide-client
+      app: ping-pong-client
       mode: cofide
   template:
     metadata:
       labels:
-        app: ping-pong-cofide-client
+        app: ping-pong-client
         mode: cofide
     spec:
-      serviceAccountName: ping-pong-cofide-client
+      serviceAccountName: ping-pong-client
       containers:
-      - name: ping-pong-cofide-client
+      - name: ping-pong-client
         image: ghcr.io/cofide/cofide-demos/ping-pong-cofide-client:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:

--- a/workloads/ping-pong-cofide/ping-pong-cofide-server/deploy.yaml
+++ b/workloads/ping-pong-cofide/ping-pong-cofide-server/deploy.yaml
@@ -1,31 +1,31 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ping-pong-cofide-server
+  name: ping-pong-server
   labels:
-    app: ping-pong-cofide-server
+    app: ping-pong-server
     mode: cofide
 ---
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ping-pong-cofide-server
+  name: ping-pong-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ping-pong-cofide-server
+      app: ping-pong-server
       mode: cofide
   template:
     metadata:
       labels:
-        app: ping-pong-cofide-server
+        app: ping-pong-server
         mode: cofide
     spec:
-      serviceAccountName: ping-pong-cofide-server
+      serviceAccountName: ping-pong-server
       containers:
-      - name: ping-pong-cofide-server
+      - name: ping-pong-server
         image: ghcr.io/cofide/cofide-demos/ping-pong-cofide-server:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:
@@ -50,10 +50,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: ping-pong-cofide-server
+  name: ping-pong-server
 spec:
   selector:
-    app: ping-pong-cofide-server
+    app: ping-pong-server
     mode: cofide
   ports:
     - protocol: TCP

--- a/workloads/ping-pong-jwt/ping-pong-jwt-client/deploy.yaml
+++ b/workloads/ping-pong-jwt/ping-pong-jwt-client/deploy.yaml
@@ -1,30 +1,30 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ping-pong-jwt-client
+  name: ping-pong-client
   labels:
-    app: ping-pong-jwt-client
+    app: ping-pong-client
     mode: cofide
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ping-pong-jwt-client
+  name: ping-pong-client
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ping-pong-jwt-client
+      app: ping-pong-client
       mode: cofide
   template:
     metadata:
       labels:
-        app: ping-pong-jwt-client
+        app: ping-pong-client
         mode: cofide
     spec:
-      serviceAccountName: ping-pong-jwt-client
+      serviceAccountName: ping-pong-client
       containers:
-        - name: ping-pong-jwt-client
+        - name: ping-pong-client
           image: ghcr.io/cofide/cofide-demos/ping-pong-jwt-client:${IMAGE_TAG}
           resources:
             requests:

--- a/workloads/ping-pong-jwt/ping-pong-jwt-server/deploy.yaml
+++ b/workloads/ping-pong-jwt/ping-pong-jwt-server/deploy.yaml
@@ -1,30 +1,30 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ping-pong-jwt-server
+  name: ping-pong-server
   labels:
-    app: ping-pong-jwt-server
+    app: ping-pong-server
     mode: cofide
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ping-pong-jwt-server
+  name: ping-pong-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ping-pong-jwt-server
+      app: ping-pong-server
       mode: cofide
   template:
     metadata:
       labels:
-        app: ping-pong-jwt-server
+        app: ping-pong-server
         mode: cofide
     spec:
-      serviceAccountName: ping-pong-jwt-server
+      serviceAccountName: ping-pong-server
       containers:
-        - name: ping-pong-jwt-server
+        - name: ping-pong-server
           image: ghcr.io/cofide/cofide-demos/ping-pong-jwt-server:${IMAGE_TAG}
           resources:
             requests:
@@ -50,10 +50,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: ping-pong-jwt-server
+  name: ping-pong-server
 spec:
   selector:
-    app: ping-pong-jwt-server
+    app: ping-pong-server
     mode: cofide
   ports:
     - protocol: TCP

--- a/workloads/ping-pong-mesh/ping-pong-mesh-client/deploy.yaml
+++ b/workloads/ping-pong-mesh/ping-pong-mesh-client/deploy.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ping-pong-mesh-client
+  name: ping-pong-client
   labels:
-    app: ping-pong-mesh-client
+    app: ping-pong-client
     mode: cofide
 ---
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ping-pong-mesh-client
+  name: ping-pong-client
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ping-pong-mesh-client
+      app: ping-pong-client
       mode: cofide
   template:
     metadata:
       labels:
-        app: ping-pong-mesh-client
+        app: ping-pong-client
         mode: cofide
         spiffe.io/spire-managed-identity: "true"
         sidecar.istio.io/inject: "true"
@@ -31,9 +31,9 @@ spec:
             ISTIO_META_DNS_AUTO_ALLOCATE: "true"
         inject.istio.io/templates: "sidecar,spire"
     spec:
-      serviceAccountName: ping-pong-mesh-client
+      serviceAccountName: ping-pong-client
       containers:
-      - name: ping-pong-mesh-client
+      - name: ping-pong-client
         image: ghcr.io/cofide/cofide-demos/ping-pong-mesh-client:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:

--- a/workloads/ping-pong-mesh/ping-pong-mesh-server/deploy.yaml
+++ b/workloads/ping-pong-mesh/ping-pong-mesh-server/deploy.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ping-pong-mesh-server
+  name: ping-pong-server
   labels:
-    app: ping-pong-mesh-server
+    app: ping-pong-server
     mode: cofide
 ---
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ping-pong-mesh-server
+  name: ping-pong-server
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: ping-pong-mesh-server
+      app: ping-pong-server
       mode: cofide
   template:
     metadata:
       labels:
-        app: ping-pong-mesh-server
+        app: ping-pong-server
         mode: cofide
         sidecar.istio.io/inject: "true"
       annotations:
@@ -30,9 +30,9 @@ spec:
             ISTIO_META_DNS_AUTO_ALLOCATE: "true"
         inject.istio.io/templates: "sidecar,spire"
     spec:
-      serviceAccountName: ping-pong-mesh-server
+      serviceAccountName: ping-pong-server
       containers:
-      - name: ping-pong-mesh-server
+      - name: ping-pong-server
         image: ghcr.io/cofide/cofide-demos/ping-pong-mesh-server:${IMAGE_TAG}
         imagePullPolicy: Always
         resources:
@@ -49,10 +49,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: ping-pong-mesh-server
+  name: ping-pong-server
 spec:
   selector:
-    app: ping-pong-mesh-server
+    app: ping-pong-server
     mode: cofide
   ports:
     - protocol: TCP


### PR DESCRIPTION
This reverts commit 88e1610e9b8b62ea195e3202b6822d6dc464945b.

In hindsight, it causes more trouble than it saves...