### PR TITLE
Expose multiple ports on the server

### DIFF
--- a/workloads/ping-pong-cofide/ping-pong-cofide-server/deploy.yaml
+++ b/workloads/ping-pong-cofide/ping-pong-cofide-server/deploy.yaml
@@ -33,6 +33,8 @@ spec:
             cpu: "100m"
         ports:
         - containerPort: 8443
+        - containerPort: 8080
+          name: http
         volumeMounts:
             - name: spiffe-workload-api
               mountPath: /spiffe-workload-api


### PR DESCRIPTION
This allows tests using the demo to verify that traffic is being directed to the right port and not just falling back to the only available port.