### PR TITLE
feat: add ping-pong-exchange demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ just build-ping-pong
 just build-ping-pong-mesh
 just build-ping-pong-cofide
 just build-ping-pong-jwt
+just build-ping-pong-exchange
 just build-aws-oidc
 
 # Check required tools are installed
@@ -38,6 +39,7 @@ This repo contains demo applications showcasing [Cofide](https://www.cofide.io) 
 | `ping-pong-jwt` | SPIFFE JWT-SVIDs over HTTP | Uses Bearer tokens; server returns its own SPIFFE ID |
 | `ping-pong-mesh` | Plain HTTP | No auth; intended for use behind a service mesh |
 | `ping-pong-cofide` | SPIFFE mTLS via Cofide SDK | Uses `cofide-sdk-go` for XDS service discovery |
+| `ping-pong-exchange` | JWT + OAuth 2.0 Token Exchange (RFC 8693) | Single binary; supports `client`, `server`, and `relay` modes |
 | `aws-oidc` | SPIFFE + AWS STS OIDC | Demonstrates AWS credential exchange via SPIFFE identity |
 
 ### Key Patterns
@@ -49,6 +51,8 @@ This repo contains demo applications showcasing [Cofide](https://www.cofide.io) 
 **ping-pong-jwt**: Client fetches JWT-SVID from workload API and sends as `Authorization: Bearer` header. Server validates via workload API, responds with its own SPIFFE ID.
 
 **ping-pong-cofide**: Wraps mTLS with `cofide-sdk-go/http/server` and `cofide-sdk-go/http/client`. Supports XDS-based service discovery configured via environment variables.
+
+**ping-pong-exchange**: Single binary controlled by `PING_PONG_MODE` (`client`/`server`/`relay`). On startup, fetches the OIDC discovery document from `EXCHANGE_URL` to locate the token and JWKS endpoints. Clients exchange their JWT-SVID for an audience-scoped access token (RFC 8693) and send it as a `Bearer` credential. The server validates the token signature via JWKS, checks audience/subject, and optionally enforces an `act` claim for delegated (relay) tokens.
 
 ### Key Dependencies
 

--- a/Justfile
+++ b/Justfile
@@ -18,7 +18,7 @@ check-deps:
     done
     echo "All dependencies installed"
 
-build-demos: build-ping-pong build-ping-pong-mesh build-ping-pong-cofide build-aws-oidc build-ping-pong-jwt
+build-demos: build-ping-pong build-ping-pong-mesh build-ping-pong-cofide build-aws-oidc build-ping-pong-jwt build-ping-pong-exchange
 
 build-ping-pong:
   ko build --platform=linux/amd64,linux/arm64 github.com/cofide/cofide-demos/workloads/ping-pong/ping-pong-server -B -t $RELEASE_TAG
@@ -35,6 +35,9 @@ build-ping-pong-cofide:
 build-ping-pong-jwt:
   ko build --platform=linux/amd64,linux/arm64 github.com/cofide/cofide-demos/workloads/ping-pong-jwt/ping-pong-jwt-server -B -t $RELEASE_TAG
   ko build --platform=linux/amd64,linux/arm64 github.com/cofide/cofide-demos/workloads/ping-pong-jwt/ping-pong-jwt-client -B -t $RELEASE_TAG
+
+build-ping-pong-exchange:
+  ko build --platform=linux/amd64,linux/arm64 github.com/cofide/cofide-demos/workloads/ping-pong-exchange -B -t $RELEASE_TAG
 
 build-aws-oidc:
   ko build --platform=linux/amd64,linux/arm64 github.com/cofide/cofide-demos/workloads/aws-oidc/aws-oidc-consumer -B -t $RELEASE_TAG

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/cofide/cofide-sdk-go v0.4.2
 	github.com/gin-gonic/gin v1.12.0
-	github.com/go-jose/go-jose/v4 v4.1.3
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/prometheus/client_golang v1.23.2
 )
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/cofide/cofide-sdk-go v0.4.2
 	github.com/gin-gonic/gin v1.12.0
+	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/prometheus/client_golang v1.23.2
 )
 
@@ -44,7 +45,6 @@ require (
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
-github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
-github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
+github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/workloads/ping-pong-exchange/README.md
+++ b/workloads/ping-pong-exchange/README.md
@@ -1,0 +1,133 @@
+# ping-pong-exchange
+
+A ping-pong demo that demonstrates cross-trust-domain workload authentication using OAuth 2.0 Token Exchange ([RFC 8693](https://www.rfc-editor.org/rfc/rfc8693)) with SPIFFE JWT-SVIDs.
+
+## What it demonstrates
+
+Instead of using mTLS directly, workloads authenticate by exchanging their SPIFFE JWT-SVID for an OAuth 2.0 access token at a central token exchange service. This allows workloads in different trust domains to authenticate to each other without requiring direct X.509 trust between the domains — only the token exchange service needs to be trusted by both sides.
+
+The demo supports three operating modes:
+
+- **client**: Periodically sends a ping to a server. Before each request, the client fetches its JWT-SVID from the SPIFFE Workload API, exchanges it for an access token scoped to the server's SPIFFE ID, and sends the token as a `Bearer` credential.
+- **server**: Receives ping requests. Validates the `Bearer` token by fetching the token exchange service's JWKS, verifying the signature, checking the audience matches its own SPIFFE ID, and checking the subject matches the expected client SPIFFE ID. Responds with `...pong`.
+- **relay**: Combines both roles. Accepts authenticated ping requests from a client (acting as a server), then performs a delegated token exchange — presenting the incoming access token as the subject token and its own JWT-SVID as the actor token — and forwards the ping to a downstream server. This demonstrates [RFC 8693 impersonation/delegation](https://www.rfc-editor.org/rfc/rfc8693#section-1.1) across a chain of services.
+
+### Token exchange flow
+
+```mermaid
+sequenceDiagram
+    participant WA as Workload API
+    participant C as Client
+    participant E as Exchange Service
+    participant S as Server
+
+    C->>WA: FetchJWTSVID(aud=exchange /token)
+    WA-->>C: JWT-SVID
+
+    C->>E: POST /token (subject_token=SVID, audience=server SPIFFE ID)
+    E-->>C: access_token (sub=client, aud=server SPIFFE ID)
+
+    C->>S: GET / Authorization: Bearer <access_token>
+    S->>E: GET /keys (JWKS)
+    E-->>S: JWKS
+    S->>S: verify signature, audience, subject
+    S-->>C: "...pong"
+```
+
+### Relay (delegated token) flow
+
+When a relay sits between the client and the server, it performs a delegated token exchange ([RFC 8693 §1.1](https://www.rfc-editor.org/rfc/rfc8693#section-1.1)), combining the incoming subject token with its own JWT-SVID as the actor token. The resulting token carries both a `sub` (original client) and an `act.sub` (relay), so the server can verify the full delegation chain.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant E as Exchange Service
+    participant R as Relay
+    participant S as Server
+
+    C->>E: POST /token (subject=client SVID, aud=relay SPIFFE ID)
+    E-->>C: access_token (sub=client, aud=relay)
+
+    C->>R: GET / Bearer <client→relay token>
+    R->>E: GET /keys
+    E-->>R: JWKS
+    R->>R: verify token (sub=client, aud=relay)
+
+    note over R: delegated exchange
+    R->>E: POST /token (subject_token=client→relay token,<br/>actor_token=relay SVID, aud=server SPIFFE ID)
+    E-->>R: delegated token (sub=client, act.sub=relay, aud=server)
+
+    R->>S: GET / Bearer <delegated token>
+    S->>E: GET /keys
+    E-->>S: JWKS
+    S->>S: verify token (sub=client, act.sub=relay, aud=server)
+    S-->>R: "...pong"
+    R-->>C: "...pong"
+```
+
+The token exchange service must implement:
+- `POST /token` — RFC 8693 token exchange endpoint
+- `GET /keys` — JWKS endpoint for token verification
+
+## Configuration
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PING_PONG_MODE` | Yes | — | Operating mode: `client`, `server`, or `relay` |
+| `EXCHANGE_URL` | Yes | — | Base URL of the OAuth 2.0 token exchange service (e.g. `https://exchange.example.com`). The `/token` and `/keys` paths are appended automatically. |
+| `ACTOR_SPIFFE_ID` | No | — | SPIFFE ID of the expected actor in delegated tokens. When set, the server requires the token to contain an `act` claim (RFC 8693 §4.4) whose `sub` matches this value. |
+| `CLIENT_SPIFFE_ID` | server, relay | — | SPIFFE ID of the client workload to authorize (e.g. `spiffe://trust-domain-a/client`) |
+| `SERVER_SPIFFE_ID` | client, relay | — | SPIFFE ID of the downstream server, used as the token audience (e.g. `spiffe://trust-domain-b/server`) |
+| `PING_PONG_SERVICE_HOST` | client, relay | `ping-pong-server.demo` | Hostname of the downstream server |
+| `PING_PONG_SERVICE_PORT` | client, relay | `8443` | Port of the downstream server |
+| `PING_PONG_SERVER_LISTEN_ADDRESS` | server, relay | `:8443` | Address to listen on |
+| `SPIFFE_ENDPOINT_SOCKET` | No | `unix:///spiffe-workload-api/spire-agent.sock` | Path to the SPIFFE Workload API socket |
+
+## Deployment
+
+The workload expects access to a SPIFFE Workload API socket, provided by the `csi.spiffe.io` CSI driver in the Kubernetes manifests.
+
+### Build
+
+```bash
+just build-ping-pong-exchange
+```
+
+Or directly with `ko`:
+
+```bash
+KO_DOCKER_REPO=ghcr.io/cofide/cofide-demos ko build ./workloads/ping-pong-exchange
+```
+
+### Deploy to Kubernetes
+
+The `deploy-*.yaml` manifests use shell-style variable substitution for environment-specific values. Substitute the variables before applying, for example with `envsubst`:
+
+```bash
+export IMAGE_TAG=latest
+export EXCHANGE_URL=https://exchange.example.com
+export CLIENT_SPIFFE_ID=spiffe://trust-domain-a/ns/demo/sa/ping-pong-client
+export SERVER_SPIFFE_ID=spiffe://trust-domain-b/ns/demo/sa/ping-pong-server
+export PING_PONG_SERVER_SERVICE_HOST=ping-pong-server.demo
+export PING_PONG_SERVER_SERVICE_PORT=8443
+
+envsubst < deploy-server.yaml | kubectl apply -f -
+envsubst < deploy-client.yaml | kubectl apply -f -
+```
+
+To deploy the relay topology (client → relay → server):
+
+```bash
+# CLIENT_SPIFFE_ID and SERVER_SPIFFE_ID refer to the relay's client/server respectively
+envsubst < deploy-relay.yaml | kubectl apply -f -
+```
+
+### Manifest summary
+
+| Manifest | Mode | Creates |
+|----------|------|---------|
+| `deploy-client.yaml` | `client` | ServiceAccount, Deployment |
+| `deploy-server.yaml` | `server` | ServiceAccount, Service (port 8443), Deployment |
+| `deploy-relay.yaml` | `relay` | ServiceAccount, Service (port 8443), Deployment |

--- a/workloads/ping-pong-exchange/README.md
+++ b/workloads/ping-pong-exchange/README.md
@@ -4,7 +4,7 @@ A ping-pong demo that demonstrates cross-trust-domain workload authentication us
 
 ## What it demonstrates
 
-Instead of using mTLS directly, workloads authenticate by exchanging their SPIFFE JWT-SVID for an OAuth 2.0 access token at a central token exchange service. This allows workloads in different trust domains to authenticate to each other without requiring direct X.509 trust between the domains — only the token exchange service needs to be trusted by both sides.
+Instead of using mTLS, workloads authenticate by exchanging their SPIFFE JWT-SVID for an OAuth 2.0 access token at a central token exchange service. This allows workloads in different trust domains to authenticate to each other without requiring direct trust between the domains — only the token exchange service needs to be trusted by both sides.
 
 The demo supports three operating modes:
 

--- a/workloads/ping-pong-exchange/deploy-client.yaml
+++ b/workloads/ping-pong-exchange/deploy-client.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ping-pong-client
+  labels:
+    app: ping-pong-client
+    mode: exchange
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-pong-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ping-pong-client
+      mode: exchange
+  template:
+    metadata:
+      labels:
+        app: ping-pong-client
+        mode: exchange
+    spec:
+      serviceAccountName: ping-pong-client
+      containers:
+        - name: ping-pong-client
+          image: ghcr.io/cofide/cofide-demos/ping-pong-exchange:${IMAGE_TAG}
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+          env:
+            - name: PING_PONG_MODE
+              value: client
+            - name: EXCHANGE_URL
+              value: ${EXCHANGE_URL}
+            - name: PING_PONG_SERVICE_HOST
+              value: "${PING_PONG_SERVER_SERVICE_HOST}"
+            - name: PING_PONG_SERVICE_PORT
+              value: "${PING_PONG_SERVER_SERVICE_PORT}"
+            - name: SERVER_SPIFFE_ID
+              value: ${SERVER_SPIFFE_ID}
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///spiffe-workload-api/spire-agent.sock
+          volumeMounts:
+            - name: spiffe-workload-api
+              mountPath: /spiffe-workload-api
+              readOnly: true
+      volumes:
+        - name: spiffe-workload-api
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true

--- a/workloads/ping-pong-exchange/deploy-client.yaml
+++ b/workloads/ping-pong-exchange/deploy-client.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ping-pong-client
   labels:
     app: ping-pong-client
-    mode: exchange
+    type: exchange
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -15,12 +15,12 @@ spec:
   selector:
     matchLabels:
       app: ping-pong-client
-      mode: exchange
+      type: exchange
   template:
     metadata:
       labels:
         app: ping-pong-client
-        mode: exchange
+        type: exchange
     spec:
       serviceAccountName: ping-pong-client
       containers:

--- a/workloads/ping-pong-exchange/deploy-relay.yaml
+++ b/workloads/ping-pong-exchange/deploy-relay.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ping-pong-relay
+  labels:
+    app: ping-pong-relay
+    mode: exchange
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ping-pong-relay
+  labels:
+    app: ping-pong-relay
+    mode: exchange
+spec:
+  selector:
+    app: ping-pong-relay
+    mode: exchange
+  ports:
+    - name: http
+      port: 8443
+      targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-pong-relay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ping-pong-relay
+      mode: exchange
+  template:
+    metadata:
+      labels:
+        app: ping-pong-relay
+        mode: exchange
+    spec:
+      serviceAccountName: ping-pong-relay
+      containers:
+        - name: ping-pong-relay
+          image: ghcr.io/cofide/cofide-demos/ping-pong-exchange:${IMAGE_TAG}
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+          env:
+            - name: PING_PONG_MODE
+              value: relay
+            - name: CLIENT_SPIFFE_ID
+              value: ${CLIENT_SPIFFE_ID}
+            - name: EXCHANGE_URL
+              value: ${EXCHANGE_URL}
+            - name: PING_PONG_SERVICE_HOST
+              value: "${PING_PONG_SERVER_SERVICE_HOST}"
+            - name: PING_PONG_SERVICE_PORT
+              value: "${PING_PONG_SERVER_SERVICE_PORT}"
+            - name: SERVER_SPIFFE_ID
+              value: ${SERVER_SPIFFE_ID}
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///spiffe-workload-api/spire-agent.sock
+          volumeMounts:
+            - name: spiffe-workload-api
+              mountPath: /spiffe-workload-api
+              readOnly: true
+      volumes:
+        - name: spiffe-workload-api
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true

--- a/workloads/ping-pong-exchange/deploy-relay.yaml
+++ b/workloads/ping-pong-exchange/deploy-relay.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ping-pong-relay
   labels:
     app: ping-pong-relay
-    mode: exchange
+    type: exchange
 ---
 apiVersion: v1
 kind: Service
@@ -12,11 +12,11 @@ metadata:
   name: ping-pong-relay
   labels:
     app: ping-pong-relay
-    mode: exchange
+    type: exchange
 spec:
   selector:
     app: ping-pong-relay
-    mode: exchange
+    type: exchange
   ports:
     - name: http
       port: 8443
@@ -31,12 +31,12 @@ spec:
   selector:
     matchLabels:
       app: ping-pong-relay
-      mode: exchange
+      type: exchange
   template:
     metadata:
       labels:
         app: ping-pong-relay
-        mode: exchange
+        type: exchange
     spec:
       serviceAccountName: ping-pong-relay
       containers:

--- a/workloads/ping-pong-exchange/deploy-server.yaml
+++ b/workloads/ping-pong-exchange/deploy-server.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ping-pong-server
+  labels:
+    app: ping-pong-server
+    mode: exchange
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ping-pong-server
+  labels:
+    app: ping-pong-server
+    mode: exchange
+spec:
+  selector:
+    app: ping-pong-server
+    mode: exchange
+  ports:
+    - name: http
+      port: 8443
+      targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ping-pong-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ping-pong-server
+      mode: exchange
+  template:
+    metadata:
+      labels:
+        app: ping-pong-server
+        mode: exchange
+    spec:
+      serviceAccountName: ping-pong-server
+      containers:
+        - name: ping-pong-server
+          image: ghcr.io/cofide/cofide-demos/ping-pong-exchange:${IMAGE_TAG}
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+          env:
+            - name: PING_PONG_MODE
+              value: server
+            - name: ACTOR_SPIFFE_ID
+              value: ${ACTOR_SPIFFE_ID}
+            - name: CLIENT_SPIFFE_ID
+              value: ${CLIENT_SPIFFE_ID}
+            - name: EXCHANGE_URL
+              value: ${EXCHANGE_URL}
+            - name: SPIFFE_ENDPOINT_SOCKET
+              value: unix:///spiffe-workload-api/spire-agent.sock
+          volumeMounts:
+            - name: spiffe-workload-api
+              mountPath: /spiffe-workload-api
+              readOnly: true
+      volumes:
+        - name: spiffe-workload-api
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true

--- a/workloads/ping-pong-exchange/deploy-server.yaml
+++ b/workloads/ping-pong-exchange/deploy-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ping-pong-server
   labels:
     app: ping-pong-server
-    mode: exchange
+    type: exchange
 ---
 apiVersion: v1
 kind: Service
@@ -12,11 +12,11 @@ metadata:
   name: ping-pong-server
   labels:
     app: ping-pong-server
-    mode: exchange
+    type: exchange
 spec:
   selector:
     app: ping-pong-server
-    mode: exchange
+    type: exchange
   ports:
     - name: http
       port: 8443
@@ -31,12 +31,12 @@ spec:
   selector:
     matchLabels:
       app: ping-pong-server
-      mode: exchange
+      type: exchange
   template:
     metadata:
       labels:
         app: ping-pong-server
-        mode: exchange
+        type: exchange
     spec:
       serviceAccountName: ping-pong-server
       containers:

--- a/workloads/ping-pong-exchange/exchange.go
+++ b/workloads/ping-pong-exchange/exchange.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ExchangeClient performs RFC 8693 token exchange requests against a token endpoint.
+type ExchangeClient struct {
+	tokenURL string
+	client   *http.Client
+}
+
+// ExchangeParams holds the parameters for an RFC 8693 token exchange request.
+type ExchangeParams struct {
+	ClientAssertionType string
+	ClientAssertion     string
+	SubjectTokenType    string
+	SubjectToken        string
+	ActorToken          string
+	ActorTokenType      string
+	Audience            string
+	Scopes              []string
+}
+
+// ExchangeResult holds the access token returned by a successful token exchange.
+type ExchangeResult struct {
+	Token string
+}
+
+// Exchange performs an RFC 8693 token exchange and returns the resulting access token.
+func (c *ExchangeClient) Exchange(ctx context.Context, params ExchangeParams) (ExchangeResult, error) {
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	form.Set("client_assertion_type", params.ClientAssertionType)
+	form.Set("client_assertion", params.ClientAssertion)
+	form.Set("subject_token_type", params.SubjectTokenType)
+	form.Set("subject_token", params.SubjectToken)
+	if params.ActorToken != "" {
+		form.Set("actor_token", params.ActorToken)
+		form.Set("actor_token_type", params.ActorTokenType)
+	}
+	form.Set("audience", params.Audience)
+	if len(params.Scopes) > 0 {
+		form.Set("scope", strings.Join(params.Scopes, " "))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return ExchangeResult{}, fmt.Errorf("failed to create exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return ExchangeResult{}, fmt.Errorf("failed to send exchange request: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return ExchangeResult{}, fmt.Errorf("failed to read exchange response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return ExchangeResult{}, fmt.Errorf("exchange request failed with status %d: %s", resp.StatusCode, body)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	err = json.Unmarshal(body, &tokenResp)
+	if err != nil {
+		return ExchangeResult{}, fmt.Errorf("failed to unmarshal exchange response: %w", err)
+	}
+
+	if tokenResp.AccessToken == "" {
+		return ExchangeResult{}, errors.New("token not found in exchange response")
+	}
+
+	return ExchangeResult{Token: tokenResp.AccessToken}, nil
+}

--- a/workloads/ping-pong-exchange/jwks.go
+++ b/workloads/ping-pong-exchange/jwks.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+const jwksTTL = 5 * time.Minute
+
+// JWKSFetcher fetches and caches a JSON Web Key Set from a remote URL,
+// refreshing it after jwksTTL has elapsed.
+type JWKSFetcher struct {
+	url    string
+	client *http.Client
+	mu     sync.RWMutex
+	jwks   *jose.JSONWebKeySet
+	expiry time.Time
+}
+
+// GetJWKS returns the cached JWKS if still valid, or fetches a fresh copy from
+// the remote URL and resets the TTL.
+func (f *JWKSFetcher) GetJWKS() (*jose.JSONWebKeySet, error) {
+	f.mu.RLock()
+	if f.jwks != nil && time.Now().Before(f.expiry) {
+		jwks := f.jwks
+		f.mu.RUnlock()
+		return jwks, nil
+	}
+	f.mu.RUnlock()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.jwks != nil && time.Now().Before(f.expiry) {
+		return f.jwks, nil
+	}
+	jwks, err := f.fetch()
+	if err != nil {
+		return nil, err
+	}
+	f.jwks = jwks
+	f.expiry = time.Now().Add(jwksTTL)
+	return f.jwks, nil
+}
+
+// fetchJWKS retrieves and parses the JWKS from the given URL.
+func (f *JWKSFetcher) fetch() (*jose.JSONWebKeySet, error) {
+	resp, err := f.client.Get(f.url)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var jwks jose.JSONWebKeySet
+	err = json.NewDecoder(resp.Body).Decode(&jwks)
+	if err != nil {
+		return nil, err
+	}
+	return &jwks, nil
+}

--- a/workloads/ping-pong-exchange/main.go
+++ b/workloads/ping-pong-exchange/main.go
@@ -1,0 +1,486 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"slices"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+const (
+	ModeClient = "client"
+	ModeServer = "server"
+	ModeRelay  = "relay"
+)
+
+// Env holds configuration loaded from environment variables.
+type Env struct {
+	ActorSPIFFEID    string
+	ClientSPIFFEID   string
+	ExchangeURL      string
+	ListenAddress    string
+	Mode             string
+	ServerURL        string
+	ServerSPIFFEID   string
+	SpiffeSocketPath string
+}
+
+var allowedSignatureAlgs = []jose.SignatureAlgorithm{jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512, jose.ES256, jose.ES384, jose.ES512}
+
+// actorClaim represents the RFC 8693 "act" (actor) claim in a delegated token.
+type actorClaim struct {
+	Sub string `json:"sub"`
+}
+
+// tokenClaims extends the standard JWT claims with the RFC 8693 "act" claim.
+type tokenClaims struct {
+	jwt.Claims
+	Act *actorClaim `json:"act,omitempty"`
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+	if err := run(ctx, getEnv()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// getEnv reads and validates all required environment variables, exiting on error.
+func getEnv() *Env {
+	host := getEnvWithDefault("PING_PONG_SERVICE_HOST", "ping-pong-server.demo")
+	port := getEnvWithDefault("PING_PONG_SERVICE_PORT", "8443")
+	env := &Env{
+		ActorSPIFFEID:    getEnvWithDefault("ACTOR_SPIFFE_ID", ""),
+		ClientSPIFFEID:   getEnvWithDefault("CLIENT_SPIFFE_ID", ""),
+		ExchangeURL:      mustGetEnv("EXCHANGE_URL"),
+		ListenAddress:    getEnvWithDefault("PING_PONG_SERVER_LISTEN_ADDRESS", ":8443"),
+		Mode:             mustGetMode(),
+		ServerURL:        fmt.Sprintf("http://%s:%s", host, port),
+		ServerSPIFFEID:   getEnvWithDefault("SERVER_SPIFFE_ID", ""),
+		SpiffeSocketPath: getEnvWithDefault("SPIFFE_ENDPOINT_SOCKET", "unix:///spiffe-workload-api/spire-agent.sock"),
+	}
+
+	if env.Mode == ModeClient || env.Mode == ModeRelay {
+		if _, err := spiffeid.FromString(env.ServerSPIFFEID); err != nil {
+			slog.Error("Invalid SERVER_SPIFFE_ID", "error", err)
+			os.Exit(1)
+		}
+	}
+
+	if env.Mode == ModeServer || env.Mode == ModeRelay {
+		if _, err := spiffeid.FromString(env.ClientSPIFFEID); err != nil {
+			slog.Error("Invalid CLIENT_SPIFFE_ID", "error", err)
+			os.Exit(1)
+		}
+	}
+
+	if env.ActorSPIFFEID != "" {
+		if _, err := spiffeid.FromString(env.ActorSPIFFEID); err != nil {
+			slog.Error("Invalid ACTOR_SPIFFE_ID", "error", err)
+			os.Exit(1)
+		}
+	}
+
+	return env
+}
+
+func getEnvWithDefault(variable string, defaultValue string) string {
+	v, ok := os.LookupEnv(variable)
+	if !ok {
+		return defaultValue
+	}
+	return v
+}
+
+func mustGetMode() string {
+	mode := mustGetEnv("PING_PONG_MODE")
+	switch mode {
+	case ModeClient, ModeServer, ModeRelay:
+		return mode
+	default:
+		slog.Error("Invalid PING_PONG_MODE", "value", mode, "valid", []string{ModeClient, ModeServer, ModeRelay})
+		os.Exit(1)
+		return ""
+	}
+}
+
+func mustGetEnv(variable string) string {
+	v, ok := os.LookupEnv(variable)
+	if !ok || v == "" {
+		slog.Error("Unset environment variable", "variable", variable)
+		os.Exit(1)
+	}
+	return v
+}
+
+// run initialises shared dependencies (OIDC discovery, workload API) and starts
+// the client, server, or relay goroutine(s) depending on env.Mode.
+func run(ctx context.Context, env *Env) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	initCtx, initCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer initCancel()
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+
+	slog.Info("Starting", "mode", env.Mode)
+	slog.Info("Fetching OIDC discovery document", "issuer", env.ExchangeURL)
+	discovery, err := Discover(env.ExchangeURL, httpClient)
+	if err != nil {
+		return fmt.Errorf("OIDC discovery failed: %w", err)
+	}
+	slog.Info("OIDC discovery complete", "token_endpoint", discovery.TokenEndpoint, "jwks_uri", discovery.JWKSUri)
+
+	slog.Info("Connecting to SPIFFE workload API", "socket", env.SpiffeSocketPath)
+	wlClient, err := workloadapi.New(initCtx, workloadapi.WithAddr(env.SpiffeSocketPath))
+	if err != nil {
+		return fmt.Errorf("failed to create workload client: %w", err)
+	}
+	defer func() { _ = wlClient.Close() }()
+
+	exchangeClient := &ExchangeClient{
+		tokenURL: discovery.TokenEndpoint,
+		client:   httpClient,
+	}
+	svidSource := &JWTSVIDSource{
+		wlClient: wlClient,
+		audience: discovery.TokenEndpoint,
+	}
+
+	wg := sync.WaitGroup{}
+
+	var client *pingPongClient
+	if env.Mode == ModeClient || env.Mode == ModeRelay {
+		client = &pingPongClient{
+			env:            env,
+			svidSource:     svidSource,
+			exchangeClient: exchangeClient,
+			client:         &http.Client{Timeout: 10 * time.Second},
+		}
+	}
+	if env.Mode == ModeClient {
+		wg.Go(func() { client.run(ctx) })
+	}
+
+	var serverErr error
+	if env.Mode == ModeServer || env.Mode == ModeRelay {
+		server := pingPongServer{
+			env:              env,
+			authorizedClient: spiffeid.RequireFromString(env.ClientSPIFFEID),
+			exchangeClient:   exchangeClient,
+			svidSource:       svidSource,
+			jwksFetcher:      &JWKSFetcher{url: discovery.JWKSUri, client: httpClient},
+			client:           client,
+		}
+		if env.ActorSPIFFEID != "" {
+			id := spiffeid.RequireFromString(env.ActorSPIFFEID)
+			server.authorizedActor = &id
+		}
+		wg.Go(func() {
+			defer cancel()
+			serverErr = server.run(ctx)
+		})
+	}
+
+	wg.Wait()
+	return serverErr
+}
+
+// pingPongClient periodically sends a ping to the server, using a token-exchanged
+// JWT as its credential.
+type pingPongClient struct {
+	env            *Env
+	svidSource     *JWTSVIDSource
+	exchangeClient *ExchangeClient
+	client         *http.Client
+}
+
+// run loops every 5 seconds: fetches a JWT-SVID, exchanges it for an access
+// token, and sends a ping to the server until ctx is cancelled.
+func (c *pingPongClient) run(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		svid, err := c.svidSource.GetSVID(ctx)
+		if err != nil {
+			slog.With("error", err).Warn("Failed to obtain SVID")
+			continue
+		}
+		slog.Info("Obtained JWT-SVID", "id", svid.ID.String())
+
+		token, err := c.doTokenExchange(ctx, svid)
+		if err != nil {
+			slog.With("error", err).Warn("Failed to obtain access token")
+			continue
+		}
+		slog.Info("Obtained access token via token exchange", "audience", c.env.ServerSPIFFEID)
+
+		slog.Info("Sending ping", "url", c.env.ServerURL)
+		body, err := c.ping(ctx, token)
+		if err != nil {
+			slog.Error("Failed to reach server", "error", err)
+		} else {
+			slog.Info("Received pong", "response", string(body))
+		}
+	}
+}
+
+// doTokenExchange exchanges the given JWT-SVID for an access token scoped to
+// the configured server SPIFFE ID.
+func (c *pingPongClient) doTokenExchange(ctx context.Context, svid *jwtsvid.SVID) (string, error) {
+	exchangeResult, err := c.exchangeClient.Exchange(ctx, ExchangeParams{
+		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-spiffe",
+		ClientAssertion:     svid.Marshal(),
+		SubjectTokenType:    "urn:ietf:params:oauth:token-type:jwt-spiffe",
+		SubjectToken:        svid.Marshal(),
+		Audience:            c.env.ServerSPIFFEID,
+	})
+	if err != nil {
+		return "", err
+	}
+	return exchangeResult.Token, nil
+}
+
+// ping sends a GET request to the server with the token as a Bearer credential
+// and returns the response body.
+func (c *pingPongClient) ping(ctx context.Context, clientToken string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.env.ServerURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", clientToken))
+
+	r, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = r.Body.Close()
+	}()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d: %s", r.StatusCode, body)
+	}
+	return body, nil
+}
+
+// pingPongServer validates incoming JWT bearer tokens and responds with a pong.
+// When a client is set (relay mode) it instead performs a delegated token exchange
+// and forwards the request downstream.
+type pingPongServer struct {
+	env              *Env
+	authorizedClient spiffeid.ID
+	authorizedActor  *spiffeid.ID // nil if actor validation not required
+	exchangeClient   *ExchangeClient
+	svidSource       *JWTSVIDSource
+	jwksFetcher      *JWKSFetcher
+	client           *pingPongClient
+}
+
+// run starts the HTTP server and blocks until ctx is cancelled or a fatal error occurs.
+func (s *pingPongServer) run(ctx context.Context) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handler)
+
+	server := &http.Server{
+		Addr:              s.env.ListenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second * 10,
+		BaseContext:       func(_ net.Listener) context.Context { return ctx },
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			slog.Error("Server shutdown error", "error", err)
+		}
+	}()
+
+	slog.Info("Server listening", "address", s.env.ListenAddress)
+	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("failed to serve: %w", err)
+	}
+
+	return nil
+}
+
+// httpError carries an HTTP status code and message for use in handler responses.
+type httpError struct {
+	status  int
+	message string
+}
+
+func (e *httpError) Error() string { return e.message }
+
+// handler authenticates the incoming request and either relays it downstream
+// (relay mode) or writes a "pong" response (server mode).
+func (s *pingPongServer) handler(w http.ResponseWriter, r *http.Request) {
+	subjectID, token, svid, herr := s.authenticate(r)
+	if herr != nil {
+		w.WriteHeader(herr.status)
+		_, _ = w.Write([]byte(herr.message))
+		return
+	}
+
+	if s.client != nil {
+		slog.Info("Received ping from client, forwarding to downstream server", "subject", subjectID, "downstream", s.client.env.ServerURL)
+		s.handleRelay(w, r, token, svid)
+		return
+	}
+
+	slog.Info("Received ping from client", "subject", subjectID)
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte("...pong")); err != nil {
+		slog.Error("Error writing response", "error", err)
+	} else {
+		slog.Info("Sent pong to client", "subject", subjectID)
+	}
+}
+
+// authenticate validates the Bearer token in the request, returning the verified
+// subject SPIFFE ID, raw token, and server SVID on success.
+func (s *pingPongServer) authenticate(r *http.Request) (spiffeid.ID, string, *jwtsvid.SVID, *httpError) {
+	auth := r.Header.Get("Authorization")
+	if len(auth) < 7 || auth[:7] != "Bearer " {
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "No token provided by client"}
+	}
+	token := auth[7:]
+
+	jwks, err := s.jwksFetcher.GetJWKS()
+	if err != nil {
+		slog.Error("Failed to fetch JWKS", "error", err)
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusServiceUnavailable, "Unable to fetch JWKS"}
+	}
+
+	tok, err := jwt.ParseSigned(token, allowedSignatureAlgs)
+	if err != nil {
+		slog.Warn("Failed to parse token", "error", err)
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid token"}
+	}
+
+	var claims tokenClaims
+	if err = tok.Claims(jwks, &claims); err != nil {
+		slog.Warn("Failed to verify token", "error", err)
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid token"}
+	}
+
+	if err = claims.ValidateWithLeeway(jwt.Expected{Time: time.Now()}, 0); err != nil {
+		slog.Warn("Token failed time validation", "error", err)
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid token"}
+	}
+
+	if claims.Subject == "" {
+		slog.Warn("Invalid subject in token")
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid subject in token"}
+	}
+
+	svid, err := s.svidSource.GetSVID(r.Context())
+	if err != nil {
+		slog.Error("Failed to obtain SVID", "error", err)
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusInternalServerError, "Unable to obtain SVID"}
+	}
+
+	if !slices.Contains([]string(claims.Audience), svid.ID.String()) {
+		slog.Warn("Invalid audience in token", "audience", claims.Audience, "expected", svid.ID.String())
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid audience in token"}
+	}
+
+	subjectID, err := spiffeid.FromString(claims.Subject)
+	if err != nil {
+		slog.Warn("Invalid subject in request", "subject", claims.Subject)
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid subject"}
+	}
+
+	if err := spiffeid.MatchID(s.authorizedClient)(subjectID); err != nil {
+		slog.Warn("Rejected unauthorized request", "subject", claims.Subject)
+		return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid subject"}
+	}
+
+	if s.authorizedActor != nil {
+		if claims.Act == nil || claims.Act.Sub == "" {
+			slog.Warn("Missing act claim in delegated token")
+			return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Missing act claim"}
+		}
+		actorID, err := spiffeid.FromString(claims.Act.Sub)
+		if err != nil {
+			slog.Warn("Invalid act.sub in token", "act_sub", claims.Act.Sub)
+			return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid actor"}
+		}
+		if err := spiffeid.MatchID(*s.authorizedActor)(actorID); err != nil {
+			slog.Warn("Rejected unauthorized actor", "actor", claims.Act.Sub)
+			return spiffeid.ID{}, "", nil, &httpError{http.StatusUnauthorized, "Invalid actor"}
+		}
+		slog.Info("Validated delegated token", "subject", subjectID, "actor", claims.Act.Sub, "audience", svid.ID)
+	} else {
+		slog.Info("Validated token", "subject", subjectID, "audience", svid.ID)
+	}
+
+	return subjectID, token, svid, nil
+}
+
+// handleRelay performs a token exchange and forwards the ping to the downstream server.
+func (s *pingPongServer) handleRelay(w http.ResponseWriter, r *http.Request, token string, svid *jwtsvid.SVID) {
+	slog.Info("Performing delegated token exchange", "actor", svid.ID.String(), "audience", s.env.ServerSPIFFEID)
+	exchangeResult, err := s.exchangeClient.Exchange(r.Context(), ExchangeParams{
+		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-spiffe",
+		ClientAssertion:     svid.Marshal(),
+		SubjectTokenType:    "urn:ietf:params:oauth:token-type:access_token",
+		SubjectToken:        token,
+		ActorTokenType:      "urn:ietf:params:oauth:token-type:jwt-spiffe",
+		ActorToken:          svid.Marshal(),
+		Audience:            s.env.ServerSPIFFEID,
+	})
+	if err != nil {
+		slog.Error("Failed to obtain delegated access token", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Unable to obtain access token"))
+		return
+	}
+	slog.Info("Obtained delegated access token, forwarding ping to downstream server", "url", s.client.env.ServerURL)
+
+	body, err := s.client.ping(r.Context(), exchangeResult.Token)
+	if err != nil {
+		slog.Error("Failed to reach downstream server", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Problem reaching downstream server"))
+		return
+	}
+	slog.Info("Received pong from downstream server, relaying to client")
+
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+	if _, err = w.Write(body); err != nil {
+		slog.Error("Error writing response", "error", err)
+	}
+}

--- a/workloads/ping-pong-exchange/oidc.go
+++ b/workloads/ping-pong-exchange/oidc.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// OIDCDiscovery holds the subset of OIDC discovery document fields used by this application.
+type OIDCDiscovery struct {
+	TokenEndpoint string `json:"token_endpoint"`
+	JWKSUri       string `json:"jwks_uri"`
+}
+
+// Discover fetches and parses the OIDC discovery document for the given issuer URL.
+func Discover(issuerURL string, client *http.Client) (*OIDCDiscovery, error) {
+	issuerURL = strings.TrimRight(issuerURL, "/")
+	discoveryURL := issuerURL + "/.well-known/openid-configuration"
+
+	resp, err := client.Get(discoveryURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch OIDC discovery document: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("OIDC discovery request failed with status %d", resp.StatusCode)
+	}
+
+	var doc OIDCDiscovery
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("failed to parse OIDC discovery document: %w", err)
+	}
+
+	if doc.TokenEndpoint == "" {
+		return nil, fmt.Errorf("OIDC discovery document missing token_endpoint")
+	}
+	if doc.JWKSUri == "" {
+		return nil, fmt.Errorf("OIDC discovery document missing jwks_uri")
+	}
+
+	return &doc, nil
+}

--- a/workloads/ping-pong-exchange/svid.go
+++ b/workloads/ping-pong-exchange/svid.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+// JWTSVIDSource fetches and caches a JWT-SVID for a given audience, refreshing
+// it when it is within one minute of expiry.
+type JWTSVIDSource struct {
+	wlClient *workloadapi.Client
+	audience string
+	mu       sync.Mutex
+	svid     *jwtsvid.SVID
+}
+
+// GetSVID returns a valid JWT-SVID, fetching a new one from the workload API when
+// the cached SVID is absent or within one minute of expiry.
+func (s *JWTSVIDSource) GetSVID(ctx context.Context) (*jwtsvid.SVID, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.svid == nil || time.Until(s.svid.Expiry) < time.Minute {
+		slog.Info("Fetching JWT-SVID")
+		svid, err := s.wlClient.FetchJWTSVID(ctx, jwtsvid.Params{Audience: s.audience})
+		if err != nil {
+			if s.svid != nil && time.Now().Before(s.svid.Expiry) {
+				slog.Warn("Failed to refresh JWT-SVID, using cached SVID", "error", err)
+				return s.svid, nil
+			}
+			return nil, fmt.Errorf("failed to obtain JWT-SVID: %w", err)
+		}
+		s.svid = svid
+		slog.Info("Fetched JWT-SVID", "id", svid.ID.String(), "expiry", svid.Expiry.Format(time.RFC3339))
+	} else {
+		slog.Debug("Using cached JWT-SVID", "id", s.svid.ID.String(), "expiry", s.svid.Expiry.Format(time.RFC3339))
+	}
+	return s.svid, nil
+}


### PR DESCRIPTION
A ping-pong demo that demonstrates cross-trust-domain workload
authentication using OAuth 2.0 Token Exchange ([RFC
8693](https://www.rfc-editor.org/rfc/rfc8693)) with SPIFFE JWT-SVIDs.

See workloads/ping-pong-exchange/README.md.
