### PR TITLE
chore: change jwt-spiffe -> jwt_spiffe

### DIFF
--- a/workloads/ping-pong-exchange/main.go
+++ b/workloads/ping-pong-exchange/main.go
@@ -255,7 +255,7 @@ func (c *pingPongClient) doTokenExchange(ctx context.Context, svid *jwtsvid.SVID
 	exchangeResult, err := c.exchangeClient.Exchange(ctx, ExchangeParams{
 		ClientAssertionType: "urn:ietf:params:oauth:client-assertion-type:jwt-spiffe",
 		ClientAssertion:     svid.Marshal(),
-		SubjectTokenType:    "urn:ietf:params:oauth:token-type:jwt-spiffe",
+		SubjectTokenType:    "urn:ietf:params:oauth:token-type:jwt_spiffe",
 		SubjectToken:        svid.Marshal(),
 		Audience:            c.env.ServerSPIFFEID,
 	})
@@ -457,7 +457,7 @@ func (s *pingPongServer) handleRelay(w http.ResponseWriter, r *http.Request, tok
 		ClientAssertion:     svid.Marshal(),
 		SubjectTokenType:    "urn:ietf:params:oauth:token-type:access_token",
 		SubjectToken:        token,
-		ActorTokenType:      "urn:ietf:params:oauth:token-type:jwt-spiffe",
+		ActorTokenType:      "urn:ietf:params:oauth:token-type:jwt_spiffe",
 		ActorToken:          svid.Marshal(),
 		Audience:            s.env.ServerSPIFFEID,
 	})


### PR DESCRIPTION
Credex changed the token type string from
urn:ietf:params:oauth:token-type:jwt-spiffe to
urn:ietf:params:oauth:token-type:jwt_spiffe in v0.14.0, in line with
standard token types.
